### PR TITLE
Add support for the Julia programming language

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Displays a coverage summary report in a pop-up window.
 
 Currently supports:
 
+- Julia: [Pkg.jl](https://pkgdocs.julialang.org/v1/)
 - Python: [coverage.py](https://coverage.readthedocs.io/en/6.3.2/index.html)
 - Ruby: [SimpleCov](https://github.com/simplecov-ruby/simplecov)
 - Rust: [grcov](https://github.com/mozilla/grcov#usage)

--- a/doc/nvim-coverage.txt
+++ b/doc/nvim-coverage.txt
@@ -116,6 +116,26 @@ Valid keys for {opts.lang}:
 ================================================================================
 LANGUANGE SPECIFIC SETUP                            *nvim-coverage-lang-setup*
 
+                                                        *nvim-coverage-julia*
+Julias package manager outputs code coverage files when running package tests
+with `Pkg.test(; coverage=true)`. The plugin processes these files using the
+`CoverageTools.jl` package, which is expected to be installed in the
+`@nvim-coverage` environment. The package can be installed with the following
+shell command:
+
+   `julia --project=@nvim-coverage -e 'using Pkg; Pkg.add("CoverageTools")'`
+
+No other configuration should be necessary, but the following options are
+available:
+
+    coverage_file: ~
+        File that the plugin will try to read coverage from.
+        Defaults to: `"lcov.info"`
+    coverage_command: ~
+        Command for creating `"lcov.info"` from individual coverage output
+        files.
+        Defaults to: `"julia --project=@nvim-coverage -e 'using CoverageTools; LCOV.writefile("lcov.info", process_folder("src"))"`
+
                                                         *nvim-coverage-python*
 Python (coverage.py) supports the following configuration options:
 

--- a/lua/coverage/config.lua
+++ b/lua/coverage/config.lua
@@ -36,6 +36,16 @@ local defaults = {
 		min_coverage = 80.0,
 	},
 	lang = {
+		julia = {
+            -- See https://github.com/julia-actions/julia-processcoverage
+            coverage_command = "julia --compile=min -O0 -e '" .. [[
+                !isdir("src") && (print(stderr, "No src directory found."); exit(1))
+                push!(empty!(LOAD_PATH), "@nvim-coverage", "@stdlib")
+                using CoverageTools
+                LCOV.writefile("lcov.info", process_folder("src"))
+            ]] .. "'",
+			coverage_file = "lcov.info",
+		},
 		python = {
 			coverage_file = ".coverage",
 			coverage_command = "coverage json -q -o -",

--- a/lua/coverage/languages/julia.lua
+++ b/lua/coverage/languages/julia.lua
@@ -1,0 +1,60 @@
+local M = {}
+
+local Path = require("plenary.path")
+local config = require("coverage.config")
+local util = require("coverage.util")
+-- Piggyback on everything but the load
+local python = require("coverage.languages.python")
+
+--- Returns a list of signs to be placed.
+M.sign_list = python.sign_list
+
+--- Returns a summary report.
+M.summary = python.summary
+
+--- Loads a coverage report.
+-- @param callback called with the results of the coverage report
+M.load = function(callback)
+	local julia_config = config.opts.lang.julia
+
+    -- Run the coverage command to construct the lcov.info file
+	local stderr = ""
+	local jobid = vim.fn.jobstart(julia_config.coverage_command, {
+		on_stderr = vim.schedule_wrap(function(_, data, _)
+			for _, line in ipairs(data) do
+				stderr = stderr .. line
+			end
+		end),
+		on_exit = vim.schedule_wrap(function(_, rc, _)
+            if rc ~= 0 then
+                if stderr:match("Package CoverageTools not found in current path") then
+                    local msg = "Package CoverageTools not found in current path: " ..
+                    "Is it installed in the expected environment? You can install it " ..
+                    "with the following shell command: " ..
+                    "julia --project=@nvim-coverage -e 'using Pkg; Pkg.add(\"CoverageTools\")'"
+                    vim.notify(msg, vim.log.levels.ERROR)
+                else
+				    vim.notify(stderr .. hint, vim.log.levels.ERROR)
+                end
+                return
+            end
+		end),
+	})
+    for _, rc in ipairs(vim.fn.jobwait({jobid})) do
+        if rc ~= 0 then return end
+    end
+
+    -- Check if the process above resulted in the file as expected
+	local p = Path:new(julia_config.coverage_file)
+	if not p:exists() then
+		vim.notify("No coverage data file exists.", vim.log.levels.INFO)
+		return
+	end
+
+    -- Parse the lcov file to table and pass to the callback
+    callback(util.lcov_to_table(p))
+
+    return
+end
+
+return M

--- a/lua/coverage/util.lua
+++ b/lua/coverage/util.lua
@@ -22,4 +22,69 @@ M.chain = function(a, b)
 	end
 end
 
+--- Parses a lcov files into a table,
+--- see http://ltp.sourceforge.net/coverage/lcov/geninfo.1.php for spec
+M.lcov_to_table = function(path)
+
+    local files = {}
+    local function new_file_meta()
+        return {
+            summary = {},
+            missing_lines = {},
+            executed_lines = {},
+            excluded_lines = {},
+        }
+    end
+
+    local cfile = nil -- Current file
+    local cmeta = nil -- Current metadata
+
+    for _, line in ipairs(path:readlines()) do
+        if line:match("end_of_record") then
+            -- Commit the current file
+            cmeta.summary["excluded_lines"] = 0
+            cmeta.summary["percent_covered"] = cmeta.summary.covered_lines /
+                                               cmeta.summary.num_statements * 100
+            files[cfile] = cmeta
+            -- Reset variables
+            cfile = nil
+            cmeta = nil
+        elseif line:match("SF:.+") then
+            -- SF:<absolute path to the source file>
+            cfile = line:gsub("SF:", "")
+            cmeta = new_file_meta()
+        elseif line:match("DA:%d+,%d+,?.*") then
+            -- DA:<line number>,<execution count>[,<checksum>]
+            local ls, ns = line:match("DA:(%d+),(%d+),?.*")
+            local l, n = tonumber(ls), tonumber(ns)
+            if n > 0 then
+                table.insert(cmeta.executed_lines, l)
+            else
+                table.insert(cmeta.missing_lines, l)
+            end
+        elseif line:match("LH:%d+") then
+            -- LH:<number of lines with a non-zero execution count>
+            local lh = tonumber((line:gsub("LH:", "")))
+            cmeta.summary["covered_lines"] = lh
+        elseif line:match("LF:%d+") then
+            -- LF:<number of instrumented lines>
+            local lf = tonumber((line:gsub("LF:", "")))
+            cmeta.summary["num_statements"] = lf
+        else
+            -- Everything else is uninteresting, just move on...
+        end
+    end
+
+    -- Compute global summary
+    local totals = {num_statements = 0, covered_lines = 0, excluded_lines = 0}
+    for _, meta in pairs(files) do
+        totals.num_statements = totals.num_statements + meta.summary.num_statements
+        totals.covered_lines = totals.covered_lines + meta.summary.covered_lines
+        totals.excluded_lines = totals.excluded_lines + meta.summary.excluded_lines
+    end
+    totals.percent_covered = totals.covered_lines / totals.num_statements * 100
+
+    return {meta = {}, totals = totals, files = files}
+end
+
 return M


### PR DESCRIPTION
This adds support for coverage files from Julias package manager Pkg.jl.
The package manager outputs individual files for every source file in
the project, so the CoverageTools.jl package is used to combined them
all to the standardized lcov format. This lcov files is parsed from lua
into a table directly.

The parsing utility is added to the util module, since it should be
useful for other testframeworks and languages and not just Julia.