### PR TITLE
Update Packer configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use({
   "andythigpen/nvim-coverage",
   requires = "nvim-lua/plenary.nvim",
   config = function()
-    require("user.coverage")
+    require("coverage").setup()
   end,
 })
 ```


### PR DESCRIPTION
When I copy/paste the Packer configuration section into my config file I get errors. `:lua require('user.coverage')` also gives errors.

The documentation just above the Packer section indicates that `require("coverage").setup()` is the way to go, so I tried:

```
    use({
        "andythigpen/nvim-coverage",
        requires = "nvim-lua/plenary.nvim",
        config = function()
            require("coverage").setup()
        end,
    })
```

Everything seems to work. Am I correct in assuming that the Packer example is out of date?