### PR TITLE
Fix coverage not shown if go.mod is in upwards directory

### DIFF
--- a/lua/coverage/languages/go.lua
+++ b/lua/coverage/languages/go.lua
@@ -20,8 +20,8 @@ local line_re = "^(.+):(%d+)%.%d+,(%d+)%.%d+ (%d+) (%d+)$"
 local mod_name_re = "^module (.*)$"
 
 local get_module_name = function()
-    local p = Path:new("go.mod")
-    if not p:exists() then
+    local p = Path:new("."):find_upwards("go.mod")
+    if p == "" then
         return ""
     end
     local lines = p:readlines()


### PR DESCRIPTION
Requires https://github.com/nvim-lua/plenary.nvim/pull/466