### PR TITLE
Add command to load lcov files directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently supports:
 - Ruby (json): [SimpleCov](https://github.com/simplecov-ruby/simplecov)
 - Rust (json): [grcov](https://github.com/mozilla/grcov#usage)
 - PHP (cobertura)
+- Anything that generates lcov files
 
 Branch (partial) coverage support:
 

--- a/doc/nvim-coverage.txt
+++ b/doc/nvim-coverage.txt
@@ -59,6 +59,9 @@ Valid keys for {opts}:
     sign_group: ~
         Name of the sign group used when placing the signs. See |sign-group|.
         Defaults to: `coverage`
+    lcov_file: ~
+        File that the plugin will try to read lcov coverage from.
+        Defaults to: `nil`
 
                                                          *coverage.highlights*
 Valid keys for {opts.highlights}:
@@ -260,6 +263,11 @@ The following commands are available (when configured):
 :CoverageLoad                                                  *:CoverageLoad*
     Loads a coverage report but does not display the coverage signs.
 
+:CoverageLoadLcov {file}                                   *:CoverageLoadLcov*
+    Loads a coverage report from an lcov file but does not display the coverage
+    signs. If `file` is not specified, the `lcov_file` configuration option is used
+    instead.
+
 :CoverageShow                                                  *:CoverageShow*
     Shows the coverage signs. Must call |:Coverage| or |:CoverageLoad| first.
 
@@ -284,6 +292,12 @@ LUA API                                                    *nvim-coverage-lua*
 coverage.load({place})
     Loads a coverage report. When {place} is true, also place the signs in the
     sign column.
+
+                                                        *coverage.load_lcov()*
+coverage.load_lcov({file}, {place})
+    Loads a coverage report from an lcov file. If `file` is not specified, the
+    `lcov_file` configuration option is used instead. When {place} is true, also
+    place the signs in the sign column.
 
                                                             *coverage.clear()*
 coverage.clear()

--- a/lua/coverage/config.lua
+++ b/lua/coverage/config.lua
@@ -114,6 +114,7 @@ local defaults = {
           path_mappings = {},
         }
     },
+    lcov_file = nil,
 }
 
 --- Setup configuration values.

--- a/lua/coverage/init.lua
+++ b/lua/coverage/init.lua
@@ -6,6 +6,7 @@ local highlight = require("coverage.highlight")
 local summary = require("coverage.summary")
 local report = require("coverage.report")
 local watch = require("coverage.watch")
+local lcov = require("coverage.lcov")
 
 --- Setup the coverage plugin.
 -- Also defines signs, creates highlight groups.
@@ -20,6 +21,7 @@ M.setup = function(user_opts)
         vim.cmd([[
     command! Coverage lua require('coverage').load(true)
     command! CoverageLoad lua require('coverage').load()
+    command! -nargs=? CoverageLoadLcov lua require('coverage').load_lcov(<f-args>)
     command! CoverageShow lua require('coverage').show()
     command! CoverageHide lua require('coverage').hide()
     command! CoverageToggle lua require('coverage').toggle()
@@ -68,6 +70,9 @@ M.load = function(place)
     signs.clear()
     load_lang()
 end
+
+-- Load an lcov file
+M.load_lcov = lcov.load_lcov
 
 -- Shows signs, if loaded.
 M.show = signs.show

--- a/lua/coverage/lcov.lua
+++ b/lua/coverage/lcov.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+local Path = require("plenary.path")
+local common = require("coverage.languages.common")
+local config = require("coverage.config")
+local report = require("coverage.report")
+local signs = require("coverage.signs")
+local util = require("coverage.util")
+local watch = require("coverage.watch")
+
+--- Loads a coverage report from an lcov file but does not place signs.
+--- @param file string the path to the lcov file
+--- @param place boolean true to immediately place signs
+M.load_lcov = function(file, place)
+    if file == nil then
+        file = config.opts.lcov_file
+    end
+    if file == nil then
+        vim.notify("A path to the lcov file was not supplied.", vim.log.levels.INFO)
+        return
+    end
+    local p = Path:new(file)
+    if not p:exists() then
+        vim.notify("No coverage file exists.", vim.log.levels.INFO)
+        return
+    end
+
+    local load_lcov = function()
+        if config.opts.load_coverage_cb ~= nil then
+            vim.schedule(function()
+                config.opts.load_coverage_cb("lcov")
+            end)
+        end
+
+        local result = util.lcov_to_table(p)
+
+        -- Since we don't know the actual language, use the default common
+        -- summary and sign_list.
+        report.cache(result, "common")
+        local sign_list = common.sign_list(result)
+        if place or signs.is_enabled() then
+            signs.place(sign_list)
+        else
+            signs.cache(sign_list)
+        end
+    end
+
+    watch.start(file, load_lcov)
+
+    -- When signs were enabled, calling load_lcov would disable them.
+    -- That didn't seem like good UX to me, so I disabled this.
+    -- signs.clear()
+    load_lcov()
+end
+
+
+return M


### PR DESCRIPTION
* Add a `load_lcov` function that loads an lcov file without any reference to a particular language.
* Add a `CoverageLoadLcov {file}` command that calls `load_lcov`.
* Add a `lcov_file` configuration option that `load_lcov` will default to if no file is specified.

I couldn't find any conventions on how lcov files are named by different languages/testing frameworks, so there are no sensible defaults to set for `lcov_file`. It will be up to the user to specify what works for them.

Fixes #8 