### PR TITLE
C# Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Branch (partial) coverage support:
 | Language              | Supported              |
 | --------------------- | ---------------------- |
 | C/C++                 | :x: |
-| C#                    | :x: (see wiki for details) |
+| C#                    | :heavy_check_mark: (see wiki for details) |
 | Dart                  | :heavy_check_mark: (untested) |
 | Go                    | :x: |
 | Javascript/Typescript | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Displays a coverage summary report in a pop-up window.
 Currently supports:
 
 - C/C++ (lcov)
+- C# (lcov - see wiki for details)
 - Dart (lcov)
 - Go (coverprofile)
 - Javascript/Typescript (lcov): [jest](https://jestjs.io/docs/getting-started)
@@ -25,7 +26,7 @@ Branch (partial) coverage support:
 | Language              | Supported              |
 | --------------------- | ---------------------- |
 | C/C++                 | :x: |
-| C#                    | :heavy_check_mark: (see wiki for details) |
+| C#                    | :x: |
 | Dart                  | :heavy_check_mark: (untested) |
 | Go                    | :x: |
 | Javascript/Typescript | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Branch (partial) coverage support:
 | Language              | Supported              |
 | --------------------- | ---------------------- |
 | C/C++                 | :x: |
+| C#                    | :x: (see wiki for details) |
 | Dart                  | :heavy_check_mark: (untested) |
 | Go                    | :x: |
 | Javascript/Typescript | :heavy_check_mark: |

--- a/lua/coverage/config.lua
+++ b/lua/coverage/config.lua
@@ -78,9 +78,9 @@ local defaults = {
         cpp = {
             coverage_file = "report.info",
         },
-		cs = {
-			coverage_file = "TestResults/lcov.info",
-		},
+        cs = {
+            coverage_file = "TestResults/lcov.info",
+        },
         dart = {
             coverage_file = "coverage/lcov.info",
         },

--- a/lua/coverage/config.lua
+++ b/lua/coverage/config.lua
@@ -78,6 +78,9 @@ local defaults = {
         cpp = {
             coverage_file = "report.info",
         },
+		cs = {
+			coverage_file = "TestResults/lcov.info",
+		},
         dart = {
             coverage_file = "coverage/lcov.info",
         },

--- a/lua/coverage/languages/cs.lua
+++ b/lua/coverage/languages/cs.lua
@@ -1,0 +1,28 @@
+local M = {}
+
+local Path = require("plenary.path")
+local common = require("coverage.languages.common")
+local config = require("coverage.config")
+local util = require("coverage.util")
+
+--- Returns a list of signs to be placed.
+M.sign_list = common.sign_list
+
+--- Returns a summary report.
+M.summary = common.summary
+
+--- Loads a coverage report.
+-- @param callback called with the results of the coverage report
+M.load = function(callback)
+	local cs_config = config.opts.lang.cs
+	local p = Path:new(cs_config.coverage_file)
+	if not p:exists() then
+		vim.notify("No coverage file exists.", vim.log.levels.INFO)
+		return
+	end
+
+	local result = util.lcov_to_table(p);
+	callback(result)
+end
+
+return M


### PR DESCRIPTION
Add support for coverage info in C# files using the dotnet command line. 

It's not working out of the box because of the way `dotnet test` writes the coverage results. I for myself added a test execution script to my PATH which must be run from the project root, and writes the result in a way that the coverage could be collected with the nvim-coverage extension.

Therefore I would recommend adding a wiki page with language specific hints which would contain something like this:

---

The `dotnet test` tool per default writes one coverage result per test project. In addition to that the output is not deterministic and contains a subfolder with GUID per test run which are not deleted when another test run is started.
To tackle this a script like the following is recommended to collect all coverage results in a solution and merge it to a single results file, which then can be picked up by the coverage extension.  
  
The [ReportGenerator dotnet tool](https://github.com/danielpalme/ReportGenerator) is used for merging reports  
  
The script is written in `powershell core` which should work cross platform or can be easily translated to a bash script:

```
$projectTestResultName = "coverage.cobertura.xml"

# delete all previous test result of each test project to have correct report generator input
Get-ChildItem -include $projectTestResultName -recurse | ForEach-Object { Remove-Item $_.Directory -recurse }

# run tests
dotnet test --collect:"XPlat Code Coverage"

# merge reports
reportgenerator -reports:**/TestResults/*/$projectTestResultName -reporttypes:lcov -targetdir:TestResults
```