### PR TITLE
Add support for javascriptreact coverage

### DIFF
--- a/lua/coverage/languages/javascriptreact.lua
+++ b/lua/coverage/languages/javascriptreact.lua
@@ -1,0 +1,18 @@
+local M = {}
+
+-- Javascript and Typescript currently use the exact same configuration.
+local javascript = require("coverage.languages.javascript")
+
+--- Use the same configuration as javascript
+M.config_alias = "javascript"
+
+--- Returns a list of signs to be placed.
+M.sign_list = javascript.sign_list
+
+--- Returns a summary report.
+M.summary = javascript.summary
+
+--- Loads a coverage report.
+M.load = javascript.load
+
+return M


### PR DESCRIPTION
## Issue
running :Coverage or require('coverage').load()
shows
```
coverage report not available for filetype javascriptreact
```

## What was done
create lua file which is same as javascript for javascriptreact filetype