### PR TITLE
Fix highlight commands + allow users to customize summary window options

### DIFF
--- a/doc/nvim-coverage.txt
+++ b/doc/nvim-coverage.txt
@@ -125,6 +125,8 @@ Valid keys for {opts.summary}:
         Defaults to: `0.50`
     borders: ~
         Customize the borders (see plenary window API)
+    window: ~
+        Customize the window options (see plenary window API)
     min_coverage: ~
         Minimum coverage percentage (0 < value <= 100.0).
         Values below this are highlighted with the fail group, values above

--- a/lua/coverage/config.lua
+++ b/lua/coverage/config.lua
@@ -70,6 +70,7 @@ local defaults = {
             bot = "─",
             highlight = "Normal:CoverageSummaryBorder",
         },
+        window = {},
         min_coverage = 80.0,
     },
 

--- a/lua/coverage/highlight.lua
+++ b/lua/coverage/highlight.lua
@@ -16,10 +16,10 @@ local highlight = function(group, color)
     local fg = color.fg and "guifg=" .. color.fg or "guifg=NONE"
     local bg = color.bg and "guibg=" .. color.bg or "guibg=NONE"
     local sp = color.sp and "guisp=" .. color.sp or ""
-    local hl = "highlight " .. group .. " " .. style .. " " .. fg .. " " .. bg .. " " .. sp
+    local hl = "highlight default " .. group .. " " .. style .. " " .. fg .. " " .. bg .. " " .. sp
     vim.cmd(hl)
     if color.link then
-        vim.cmd("highlight! link " .. group .. " " .. color.link)
+        vim.cmd("highlight default link " .. group .. " " .. color.link)
     end
 end
 

--- a/lua/coverage/summary.lua
+++ b/lua/coverage/summary.lua
@@ -386,10 +386,13 @@ M.show = function()
         border_opts.titlehighlight = hl_group
     end
 
+    -- get the window options
+    local win_opts = vim.tbl_deep_extend("force", {}, config.opts.summary.window)
+
     popup = window.percentage_range_window(
         adjust_width_percentage(config.opts.summary.width_percentage),
         config.opts.summary.height_percentage,
-        {},
+        win_opts,
         border_opts
     )
 


### PR DESCRIPTION
This PR does these 2 things:
- Fix highlight commands, so users can overwrite them before loading the plugin
- Expose the window options for Summary float window

**NOTE**: the most useful option for me is `winblend = 0` (the default is 15), as I have transparent background in my terminal emulator.
