### PR TITLE
fix: python - actually use the coverage-file

### DIFF
--- a/lua/coverage/init.lua
+++ b/lua/coverage/init.lua
@@ -7,6 +7,7 @@ local summary = require("coverage.summary")
 local report = require("coverage.report")
 local watch = require("coverage.watch")
 local lcov = require("coverage.lcov")
+local util = require("coverage.util")
 
 --- Setup the coverage plugin.
 -- Also defines signs, creates highlight groups.
@@ -70,7 +71,8 @@ M.load = function(place)
         lang_config ~= nil and
         lang_config.coverage_file ~= nil and
         not lang_config.disable_auto_reload then
-        watch.start(lang_config.coverage_file, load_lang)
+        local coverage_file = util.get_coverage_file(lang_config.coverage_file)
+        watch.start(coverage_file, load_lang)
     end
 
     signs.clear()

--- a/lua/coverage/languages/python.lua
+++ b/lua/coverage/languages/python.lua
@@ -30,6 +30,7 @@ M.load = function(callback)
     end
 
     local cmd = python_config.coverage_command
+    cmd = cmd .. " --data-file=" .. tostring(p)
     if python_config.only_open_buffers then
       local includes = {}
       local buffers = vim.api.nvim_list_bufs()
@@ -48,6 +49,7 @@ M.load = function(callback)
     if is_pipenv() then
         cmd = "pipenv run " .. cmd
     end
+
     local stdout = ""
     local stderr = ""
     vim.fn.jobstart(cmd, {


### PR DESCRIPTION
- When setting the coverage-file through setup, the python-integration checks if it exists, but doesn't actually use it when generating the json-report
- When setting the coverage-file through setup via a function or list, `auto_reload` is broken