### PR TITLE
feat: support nested go modules (monorepo)

### DIFF
--- a/lua/coverage/languages/go.lua
+++ b/lua/coverage/languages/go.lua
@@ -20,7 +20,7 @@ local line_re = "^(.+):(%d+)%.%d+,(%d+)%.%d+ (%d+) (%d+)$"
 local mod_name_re = "^module (.*)$"
 
 local get_module_name = function()
-    local p = Path:new("."):find_upwards("go.mod")
+    local p = Path:new(vim.fn.expand("%:p")):find_upwards("go.mod")
     if p == "" then
         return ""
     end


### PR DESCRIPTION
In case of a monorepo project (e.g. Python + Go) `go.mod` might be located somewhere in nested directories, but not in the project root.

Usage of `Path:new('.')` won't work well in that case, because it is actually a current working directory (cwd).

Change to `Path:new(vim.fn.expand("%:p"))` adds nested modules support, since `go.mod` search will be started from the location of the current file (opened in the buffer)

https://neovim.io/doc/user/builtin.html
> %		current file name
> :p		expand to full path