### PR TITLE
✨feat(filetype): Coverage summary now set the filetype `coverage`.

### DIFF
--- a/lua/coverage/summary.lua
+++ b/lua/coverage/summary.lua
@@ -304,6 +304,7 @@ end
 local set_options = function()
     local win_width = vim.api.nvim_win_get_width(popup.win_id)
     vim.api.nvim_buf_set_option(popup.bufnr, "textwidth", win_width)
+    vim.api.nvim_buf_set_option(popup.bufnr, "filetype", "coverage")
     vim.api.nvim_win_set_option(popup.win_id, "cursorline", true)
     vim.api.nvim_win_set_option(
         popup.win_id,


### PR DESCRIPTION
## Preview
Result of `:lua print(vim.bo.filetype)`
![screenshot_2024-04-29_21-37-30_498260107](https://github.com/andythigpen/nvim-coverage/assets/3357792/8d320a89-02e7-4100-9af6-ce84bfd022df)

## More info
closes #48 