### PR TITLE
feat: Add java jacoco coverage support

### DIFF
--- a/lua/coverage/config.lua
+++ b/lua/coverage/config.lua
@@ -91,6 +91,10 @@ local defaults = {
         go = {
             coverage_file = "coverage.out",
         },
+        java = {
+            coverage_file = "build/reports/jacoco/test/jacocoTestReport.xml",
+            dir_prefix = "src/main/java",
+        },
         javascript = {
             coverage_file = "coverage/lcov.info",
         },

--- a/lua/coverage/init.lua
+++ b/lua/coverage/init.lua
@@ -38,12 +38,11 @@ end
 M.load = function(place)
     local ftype = vim.bo.filetype
 
-    -- local ok, lang = pcall(require, "coverage.languages.java")
-    -- if not ok then
-    --     vim.notify("Coverage report not available for filetype " .. "coverage.languages." .. ftype)
-    --     return
-    -- end
-    local lang = java_lang
+    local ok, lang = pcall(require, "coverage.languages." .. ftype)
+    if not ok then
+        vim.notify("Coverage report not available for filetype " .. "coverage.languages." .. ftype)
+        return
+    end
 
     local load_lang = function()
         lang.load(function(result)

--- a/lua/coverage/init.lua
+++ b/lua/coverage/init.lua
@@ -8,6 +8,7 @@ local report = require("coverage.report")
 local watch = require("coverage.watch")
 local lcov = require("coverage.lcov")
 local util = require("coverage.util")
+local java_lang = require("coverage.languages.java")
 
 --- Setup the coverage plugin.
 -- Also defines signs, creates highlight groups.
@@ -37,11 +38,12 @@ end
 M.load = function(place)
     local ftype = vim.bo.filetype
 
-    local ok, lang = pcall(require, "coverage.languages." .. ftype)
-    if not ok then
-        vim.notify("Coverage report not available for filetype " .. ftype)
-        return
-    end
+    -- local ok, lang = pcall(require, "coverage.languages.java")
+    -- if not ok then
+    --     vim.notify("Coverage report not available for filetype " .. "coverage.languages." .. ftype)
+    --     return
+    -- end
+    local lang = java_lang
 
     local load_lang = function()
         lang.load(function(result)

--- a/lua/coverage/init.lua
+++ b/lua/coverage/init.lua
@@ -8,7 +8,6 @@ local report = require("coverage.report")
 local watch = require("coverage.watch")
 local lcov = require("coverage.lcov")
 local util = require("coverage.util")
-local java_lang = require("coverage.languages.java")
 
 --- Setup the coverage plugin.
 -- Also defines signs, creates highlight groups.
@@ -40,7 +39,7 @@ M.load = function(place)
 
     local ok, lang = pcall(require, "coverage.languages." .. ftype)
     if not ok then
-        vim.notify("Coverage report not available for filetype " .. "coverage.languages." .. ftype)
+        vim.notify("Coverage report not available for filetype " .. ftype)
         return
     end
 

--- a/lua/coverage/languages/java.lua
+++ b/lua/coverage/languages/java.lua
@@ -1,0 +1,175 @@
+local M = {}
+
+local Path = require "plenary.path"
+local config = require "coverage.config"
+local util = require "coverage.util"
+local cs = require "coverage.signs"
+local lom = require "lxp.lom"
+
+--- Loads a coverage report.
+-- @param callback called with results of the coverage report
+M.load = function(callback)
+    -- Try and load file
+    local opt = config.opts.lang.java.coverage_file
+    local p = Path:new(util.get_coverage_file(opt))
+    if not p:exists() then
+        vim.notify("No coverage file exists.", vim.log.levels.INFO)
+        return
+    end
+
+    local dir_prefix = config.opts.lang.java.dir_prefix .. "/"
+
+    -- Parse into object
+    local jacoco = lom.parse(vim.fn.readfile(p.filename))
+
+    -- Failed to parse, ignore.
+    if not jacoco then
+        vim.notify "Error loading XML"
+        return nil
+    end
+
+    -- Load xml
+    local data = {
+        files = {},
+        totals = {},
+    }
+
+    for _, item in ipairs(jacoco) do
+        -- We only really care about ocunter and package
+        if item.tag == "counter" then
+            -- Global stats
+            if item.attr.type == "LINE" then
+                data.totals.line = {
+                    covered = tonumber(item.attr.covered),
+                    missed = tonumber(item.attr.missed),
+                }
+            elseif item.attr.type == "BRANCH" then
+                data.totals.branch = {
+                    covered = tonumber(item.attr.covered),
+                    missed = tonumber(item.attr.missed),
+                }
+            end
+        elseif item.tag == "package" then
+            -- Where the sourcefiles live
+            local dir = dir_prefix .. item.attr.name .. "/"
+            -- Here's where the source file are stored :)
+            for _, srcfile in ipairs(item) do
+                if srcfile.tag == "sourcefile" then
+                    local fn = dir .. srcfile.attr.name
+                    data.files[fn] = {
+                        lines = {},
+                        totals = {
+                            line = { covered = 0, missed = 0 },
+                            branch = { covered = 0, missed = 0 },
+                        },
+                    }
+                    -- So, jacoco reports in terms of instructions
+                    -- which is neat, but not uh that useful for this purpose.
+                    -- I'll mark any sort of missing instructions as missed lines,
+                    -- iff no instructions were missed, check if any were covered.
+                    -- Also,, it doesn't really specify if stuff is mutually exclusive or not.
+                    -- The priority will be
+                    --     1. Missed branch
+                    --     2. Missed instruction (as line)
+                    --     3. Covered branch
+                    --     4. Covered instruction (as line)
+                    for _, srcdata in ipairs(srcfile) do
+                        if srcdata.tag == "line" then
+                            local lnr = tonumber(srcdata.attr.nr)
+                            assert(lnr, "bad linenumber")
+
+                            local mb = srcdata.attr.mb ~= "0"
+                            local mi = srcdata.attr.mi ~= "0"
+                            local cb = srcdata.attr.cb ~= "0"
+                            local ci = srcdata.attr.ci ~= "0"
+
+                            if mb and cb or mi and ci then
+                                data.files[fn].lines[lnr] = "partial"
+                            elseif mb or mi then
+                                data.files[fn].lines[lnr] = "missed"
+                            else
+                                data.files[fn].lines[lnr] = "covered"
+                            end
+                        elseif srcdata.tag == "counter" then
+                            if srcdata.attr.type == "LINE" then
+                                data.files[fn].totals.line = {
+                                    covered = tonumber(srcdata.attr.covered),
+                                    missed = tonumber(srcdata.attr.missed),
+                                }
+                            elseif srcdata.attr.type == "BRANCH" then
+                                data.files[fn].totals.branch = {
+                                    covered = tonumber(srcdata.attr.covered),
+                                    missed = tonumber(srcdata.attr.missed),
+                                }
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    callback(data)
+end
+
+--- Returns a list of signs that will be placed in buffers.
+-- This method should use the coverage data (previously generated via the load method) to
+-- return a list of signs.
+-- @return list of signs
+M.sign_list = function(data)
+    local signs = {}
+    local funcs = {
+        covered = cs.new_covered,
+        partial = cs.new_partial,
+        missed = cs.new_uncovered,
+    }
+    for fn, fdata in pairs(data.files) do
+        local bufnr = vim.fn.bufnr(fn, false)
+        -- Only do loaded buffers
+        if bufnr ~= -1 then
+            for lnum, what in pairs(fdata.lines) do
+                table.insert(signs, funcs[what](bufnr, lnum))
+            end
+        end
+    end
+
+    return signs
+end
+
+--- Returns a summary report.
+-- @return summary report
+M.summary = function(data)
+    local report = { files = {} }
+    for fn, fdata in pairs(data.files) do
+        local statements = fdata.totals.line.covered + fdata.totals.line.missed
+        local rep = {
+            filename = fn,
+            statements = statements,
+            missing = fdata.totals.line.missed,
+            branches = fdata.totals.branch.covered + fdata.totals.branch.missed,
+            partial = fdata.totals.branch.missed,
+            coverage = (1 - fdata.totals.line.missed / statements) * 100,
+        }
+        -- Avoid nan
+        if statements == 0 then
+            rep.coverage = 100
+        end
+        table.insert(report.files, rep)
+    end
+
+    report.totals = {
+        statements = data.totals.line.covered + data.totals.line.missed,
+        missing = data.totals.line.missed,
+        branches = data.totals.branch.covered + data.totals.branch.missed,
+        partial = data.totals.branch.missed,
+    }
+    if report.totals.statements == 0 then
+        report.totals.coverage = 100
+    else
+        report.totals.coverage = (1 - report.totals.missing / report.totals.statements) * 100
+    end
+
+    return report
+end
+
+return M

--- a/lua/coverage/languages/java.lua
+++ b/lua/coverage/languages/java.lua
@@ -17,7 +17,7 @@ M.load = function(callback)
         return
     end
 
-    local dir_prefix = config.opts.lang.java.dir_prefix .. "/"
+    local dir_prefix = Path:new(config.opts.lang.java.dir_prefix .. "/").filename
 
     -- Parse into object
     local jacoco = lom.parse(table.concat(vim.fn.readfile(p.filename), ""))
@@ -38,23 +38,12 @@ M.load = function(callback)
         if not tag then
             return nil
         end
-        for index, value in ipairs(tag) do
+        for _, value in ipairs(tag) do
             if value._attr.type == type_name then
                 return value._attr
             end
         end
         return nil
-        -- error(("attribute name %s not found in tag: %s"):format(type_name, vim.inspect(tag)))
-    end
-
-    local debug = function(obj)
-        print("--------DEBUG--------------")
-        print(vim.inspect(obj))
-        print("--------DEBUG--------------")
-    end
-
-    local stop = function ()
-        error("test stop")
     end
 
     -- Global stats
@@ -78,8 +67,6 @@ M.load = function(callback)
     end
 
 
-    --
-    --
     -- obtains fine grained data
     local packages = assert(jacoco.report.package, "not able to read jacoco.report.package")
     assert(type(packages) == "table")
@@ -88,8 +75,7 @@ M.load = function(callback)
 
         -- classes
         for _, class in ipairs(pack.class) do
-            -- local filename = class._attr.name
-            local filename = dir .. "/" .. class._attr.sourcefilename -- with .java
+            local filename = Path:new(dir .. "/" .. class._attr.sourcefilename).filename -- with .java
 
             -- set file total counters
             local file_total_lines = get_attr_by_type_name(class.counter, "LINE")
@@ -126,7 +112,7 @@ M.load = function(callback)
             if lines then
                 for _, line in ipairs(lines) do
                     local line_number = assert(tonumber(line._attr.nr))
-                    local filename = dir .. "/" .. src_file._attr.name
+                    local filename = Path:new(dir .. "/" .. src_file._attr.name).filename
 
                     local mb = assert(line._attr.mb) ~= "0"
                     local mi = assert(line._attr.mi) ~= "0"


### PR DESCRIPTION
Continuation of #51 

Note: This implementation requires [neotest](https://github.com/nvim-neotest/neotest), which contains a library to parse the xml.

Planning to integrate this feature with [neotest-java](https://github.com/rcasia/neotest-java), so I will probably just use my fork as I don't have any hope on this being merged any soon.

Thanks @ColdMacaroni
Thanks @andythigpen for such beatiful plugin!