### PR TITLE
Update Readme/Docs on how to setup Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Branch (partial) coverage support:
 | C#                    | :x: |
 | Dart                  | :heavy_check_mark: (untested) |
 | Go                    | :x: |
+| Java                  | :heavy_check_mark: |
 | Javascript/Typescript | :heavy_check_mark: |
 | Julia                 | :heavy_check_mark: (untested) |
 | Python                | :heavy_check_mark: |
@@ -88,6 +89,25 @@ Using lazyvim:
     end,
   },
 ```
+
+### Using Java
+In order to use the java coverage file, please ensure you include "nvim-neotest/neotest" as a dependency
+i.e
+```
+ {
+    "andythigpen/nvim-coverage",
+    dependencies = {
+      "nvim-neotest/neotest".
+    },
+    version = "*",
+    config = function()
+      require("coverage").setup({
+        auto_reload = true,
+      })
+    end,
+  },
+```
+
 
 ## Configuration
 

--- a/doc/nvim-coverage.txt
+++ b/doc/nvim-coverage.txt
@@ -165,6 +165,15 @@ Go supports the following configuration options:
     coverage_file: ~
         File that the plugin will try to read coverage from.
         Defaults to: `"coverage.out"`
+                                                            *nvim-coverage-java*
+Go supports the following configuration options:
+
+    coverage_file: ~
+        File that the plugin will try to read coverage from.
+        Defaults to: `"build/reports/jacoco/test/jacocoTestReport.xml"`
+    dir_prefix: ~
+        Java files directory prefix.
+        Defaults to: `"src/main/java"`
 
                                                     *nvim-coverage-javascript*
                                                     *nvim-coverage-typescript*


### PR DESCRIPTION
## Issue
While setting up the java dependency, I was getting 
```
Coverage report not available for filetype java
```

## Soultion
After debugging, I discovered this was because I did not install the neotest dependency which was required for java coverage to work

## what was done
- updated readme with how to setup java
- updated nvim doc on what java supports for additional options

## test
- verified on personal branch
