### PR TITLE
Handle single file coverage with jacoco

### DIFF
--- a/lua/coverage/languages/java.lua
+++ b/lua/coverage/languages/java.lua
@@ -70,10 +70,18 @@ M.load = function(callback)
     -- obtains fine grained data
     local packages = assert(jacoco.report.package, "not able to read jacoco.report.package")
     assert(type(packages) == "table")
+	if #packages == 0 then
+		packages = { packages }
+	end
+
     for _, pack in ipairs(packages) do
         local dir = dir_prefix .. pack._attr.name
 
         -- classes
+		if #pack.class == 0 then
+			pack.class = { pack.class }
+		end
+
         for _, class in ipairs(pack.class) do
             local filename = Path:new(dir .. "/" .. class._attr.sourcefilename).filename -- with .java
 
@@ -96,6 +104,10 @@ M.load = function(callback)
 
 
         end
+
+		if #pack.sourcefile == 0 then
+			pack.sourcefile = { pack.sourcefile }
+		end
 
         for _, src_file in ipairs(pack.sourcefile) do
             local lines = src_file.line


### PR DESCRIPTION
Calling `:Coverage` on a jacoco report that convers a single file causes sign coverage to not appear. This happens due to the fact that somewhere down the line (not sure if it's neotest's parser or something else), single entries are "flattened". So, for example:

```lua
{ { a = "a" } }
```

becomes

```lua
{ a = "a" }
```

thus causing loops with `ipairs` to never run. This PR checks whether these elements have been flattened and wraps them in a single-entry table.