### PR TITLE
Unified sign options with sign_define

### DIFF
--- a/doc/nvim-coverage.txt
+++ b/doc/nvim-coverage.txt
@@ -105,13 +105,13 @@ Valid keys for {opts.highlights}:
 Valid keys for {opts.signs}:
 
     covered: ~
-        Customize the highlight group and text used for covered signs.
+        Customize the highlight group and text used for covered signs. See :help sign_define for all supported options.
         Defaults to: `{ hl = "CoverageCovered", text = "▎" }`
     uncovered: ~
-        Customize the highlight group and text used for uncovered signs.
+        Customize the highlight group and text used for uncovered signs. See :help sign_define for all supported options.
         Defaults to: `{ hl = "CoverageUncovered", text = "▎" }`
     partial: ~
-        Customize the highlight group and text used for partial coverage signs.
+        Customize the highlight group and text used for partial coverage signs. See :help sign_define for all supported options.
         Defaults to: `{ hl = "CoveragePartial", text = "▎" }`
 
                                                             *coverage.summary*

--- a/lua/coverage/signs.lua
+++ b/lua/coverage/signs.lua
@@ -21,18 +21,24 @@ local default_priority = 10
 
 --- Defines signs.
 M.setup = function()
-    vim.fn.sign_define(M.name("covered"), {
-        text = config.opts.signs.covered.text,
-        texthl = config.opts.signs.covered.hl,
-    })
-    vim.fn.sign_define(M.name("uncovered"), {
-        text = config.opts.signs.uncovered.text,
-        texthl = config.opts.signs.uncovered.hl,
-    })
-    vim.fn.sign_define(M.name("partial"), {
-        text = config.opts.signs.partial.text,
-        texthl = config.opts.signs.partial.hl,
-    })
+    local signs = config.opts.signs
+
+    if signs.covered["hl"] ~= nil then
+        signs.covered["texthl"] = signs.covered["hl"]
+        signs.covered["hl"] = nil
+    end
+    if signs.uncovered["hl"] ~= nil then
+        signs.uncovered["texthl"] = signs.uncovered["hl"]
+        signs.covered["hl"] = nil
+    end
+    if signs.partial["hl"] ~= nil then
+        signs.partial["texthl"] = signs.partial["hl"]
+        signs.covered["hl"] = nil
+    end
+
+    vim.fn.sign_define(M.name("covered"), config.opts.signs.covered)
+    vim.fn.sign_define(M.name("uncovered"), config.opts.signs.uncovered)
+    vim.fn.sign_define(M.name("partial"), config.opts.signs.partial)
 end
 
 --- Returns a namespaced sign name.


### PR DESCRIPTION
now allows all options from sign_define
introduces ifs because old syntax aliased 'texthl' to 'hl'